### PR TITLE
D branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goodbot
 
-GoodGuide's IRC bot
+GoodGuide's IRC bot which connects to Slack via the IRC gatway.
 
 ## Usage
 
@@ -10,11 +10,12 @@ Type `.help` in IRC.
 
 This project is set up with leiningen.
 
-A goodbot plugin is a map with the following keys
-
-``` clojure
-{:doc {"topic" "text to display on `.help <topic>`"}
- :commands {"foo" (fn [irc message] ...)} ; a callback for when .foo is entered
+To get started on OSX:
+``` shell
+  brew install leiningen
+  git clone https://github.com/GoodGuide/goodbot.git
+  cd goodbot
+  lein run
 ```
 
-See `goodbot.plugins.ping` for a simple example.
+Goodbots can be extended via simple [plugins](src/goodbot/plugins/).

--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,6 @@
                  [irclj "0.5.0-alpha4"]
                  [com.datomic/datomic-free "0.9.4707"]
                  [org.clojure/algo.generic "0.1.0"]
-                 [clojail "1.0.6"]]
+                 [clojail "1.0.6"],
+                 [org.clojure/tools.namespace "0.2.7"]]
   :main goodbot.core)

--- a/src/goodbot/bot.clj
+++ b/src/goodbot/bot.clj
@@ -19,7 +19,7 @@
   (fn [irc message]
     (try
       (when-let [[command updated-message] (extract-command message)]
-
+        (println "COMMAND: " command (str [(:text message)]))
         (if-let [handler (select-handler plugins command)]
           (when-let [responses (handler irc updated-message)]
             (respond-with irc updated-message responses))

--- a/src/goodbot/bot.clj
+++ b/src/goodbot/bot.clj
@@ -19,10 +19,13 @@
   (fn [irc message]
     (try
       (when-let [[command updated-message] (extract-command message)]
-        (println "COMMAND: " command (str [(:text message)]))
-        (when-let [handler (select-handler plugins command)]
+
+        (if-let [handler (select-handler plugins command)]
           (when-let [responses (handler irc updated-message)]
-            (respond-with irc updated-message responses))))
+            (respond-with irc updated-message responses))
+          (respond-with irc updated-message
+            (str "Sorry, I'm not smart enough to "
+              (get updated-message :command) ". Try .help instead."))))
       (catch Throwable e
         (irclj/reply irc message (str "error: " e))
         (println (.getMessage e))

--- a/src/goodbot/core.clj
+++ b/src/goodbot/core.clj
@@ -1,12 +1,8 @@
 (ns goodbot.core
   "Chatbot for GoodGuide"
   (:require [goodbot.bot :as bot]
-            [goodbot.plugins.ping]
-            [goodbot.plugins.clojure]
-            [goodbot.plugins.vote]
-            [goodbot.plugins.data]
-            [goodbot.plugins.who]
-            [goodbot.plugins.help]))
+            [clojure.tools.namespace.find :as namespace-tools]
+            [clojure.java.io :as io]))
 
 (defn run [plugins]
   "runs a bot with the given plugins with configuration based on environment variables"
@@ -37,12 +33,15 @@
                        :server-password server-password
                        :datomic-uri datomic-uri)))
 
+(defn get-plugin-symbols []
+  (namespace-tools/find-namespaces-in-dir (io/file "src/goodbot/plugins")))
+
 (defn -main
   "Starts the bot"
   [& args]
-  (run [goodbot.plugins.ping/plugin
-        goodbot.plugins.clojure/plugin
-        goodbot.plugins.vote/plugin
-        goodbot.plugins.data/plugin
-        goodbot.plugins.who/plugin
-        goodbot.plugins.help/plugin]))
+  (let [plugins (get-plugin-symbols)]
+    (println "Loaded plugins: ")
+    (doseq [plugin plugins] (println "  " plugin))
+    (doseq [ns plugins] (require ns)) ; require all the plugin namespaces
+    (run (map (fn [plugin] (deref (ns-resolve plugin 'plugin))) plugins))))
+

--- a/src/goodbot/plugins/README.md
+++ b/src/goodbot/plugins/README.md
@@ -1,0 +1,16 @@
+# Goodbot Plugins
+
+All plugins in this directory will be loaded into Goodbot on startup.
+
+## Development
+
+A goodbot [plugin](src/goodbot/plugins/) is a map with the following keys.
+
+``` clojure
+{:doc {"topic" "text to display on `.help <topic>`"}
+ :commands {"foo" (fn [irc message] ...)} ; a callback for when .foo is entered
+```
+They define a command -> action linkage that results in a message.
+
+
+See `goodbot.plugins.ping` for a simple example.


### PR DESCRIPTION
I wanted plugin creation to be simpler so I changed the bot to discover and load all plugins located in ```/plugins```. Changed bot to respond if commands aren't found to direct user back to ```.help```. Made some doc changes to reflect plugin changes and added some setup instructions.

I can understand that plugin auto import might not fit into your overall bot vision, so feel free to reject.